### PR TITLE
Japanese minimal tokenizer

### DIFF
--- a/js/lexicon/Tokenizer.js
+++ b/js/lexicon/Tokenizer.js
@@ -9,7 +9,15 @@
     fineWordInternallyButNotExternallyArray: ['-', '\'', '-', '-'],
     wordDelimitersArray: [],
     // morphemesRegExp = /[はをがはのに。、「」、。・]+/g;
-    japaneseWordBoundaryMorphemes: ['\u3001-\u303F', '\u3040-\u309F', '\u30A0-\u30FF']
+    languages: {
+      ja: {
+        punctuationArray: ['\u3000-\u303f'],
+        wordBoundaryMorphemes: ['の','に']
+        // This list resutls in false segmentations?
+        // 'もの','いし', 'い', 'いは', 'かしら', 'かどうか', 'かい', 'か', 'かな', 'かも', 'かも知れない', 'から', 'が', 'き', 'きり', 'ぎゃ', 'く', 'くせに', 'け', 'けど', 'けん', 'こ', 'こえ', 'こそ', 'ころ', 'ごろ', 'さ', 'しか', 'して', 'し', 'すら', 'す', 'せ', 'ぜ', 'たら', 'だけ', 'だに', 'だの', 'そ', 'ぞ', 'た', 'っけ', 'ったら', 'って', 'っ', 'つ', 'つつ', 'ても', 'て', 'では', 'でも', 'で', 'といえども', 'とか', 'ところで', 'として', 'とて', 'とは', 'とも', 'と', 'どころか', 'ども', 'どんだけ', 'な', 'なぁ', 'ながら', 'など', 'なら', 'なりに', 'なり', 'なん', 'なんか', 'なんて', 'なんで', 'について', 'にて', 'に', 'には', 'にゃ', 'ね', 'ので', 'のに', 'のみ', 'の', 'は', 'ば', 'ばかり', 'ばかりか', 'ばっか', 'ばかし', 'へ', 'ほど', 'ほ', 'まで', 'までに', 'ま', 'まま', 'まんま', 'もの', 'ものの', 'もん', 'も', 'やら', 'や', 'より', 'よーん', 'よ', 'らむ', 'ら', 'わ', 'をして', 'を', 'んで','ん', 'ゟ', 'ザ', 'ママ', 'ヶ', '丈', '乍ら', '今や', '儘', '切り', '所か', '所で', '程', '草', '迄']
+        // wordBoundaryMorphemes: ['\u3040-\u309F', '\u30A0-\u30FF']
+      }
+    }
   };
   // ^(@|https?:
   var regExpEscape = function(s) {
@@ -35,12 +43,13 @@
     if (doc.morphemeSegmentationOptions) {
       doc = MorphemeSegmenter.runSegmenter(doc);
     }
+
     var orthographicTokens = [],
       orthographicWords = [],
       text = doc.orthography.trim(),
       punctuationArray = doc.punctuationArray || defaults.punctuationArray,
       wordDelimitersArray = doc.wordDelimitersArray || defaults.wordDelimitersArray,
-      wordBoundaryMorphemes = doc.wordBoundaryMorphemes,
+      wordBoundaryMorphemes = doc.wordBoundaryMorphemes || [],
       fineWordInternallyButNotExternallyArray = doc.fineWordInternallyButNotExternallyArray || defaults.fineWordInternallyButNotExternallyArray;
 
     // fineWordInternallyButNotExternallyArray = fineWordInternallyButNotExternallyArray.concat(doc.punctuation); //TODO test this
@@ -59,8 +68,19 @@
     }
 
     doc.tokenizeOnTheseArray = punctuationArray.concat(wordDelimitersArray);
-    doc.tokenizeOnTheseRegExp = new RegExp('([' + doc.tokenizeOnTheseArray.join('') + '])', 'g');
 
+    /**
+    Add language specific punctionation, and word boundary morphemesArray
+    */
+    if (!doc.language && doc.orthography.indexOf('。') > -1) {
+      doc.language = {
+        iso: 'ja'
+      };
+      doc.tokenizeOnTheseArray = doc.tokenizeOnTheseArray.concat(defaults.languages.ja.punctuationArray);
+      wordBoundaryMorphemes = wordBoundaryMorphemes.concat(defaults.languages.ja.wordBoundaryMorphemes);
+    }
+
+    doc.tokenizeOnTheseRegExp = new RegExp('([' + doc.tokenizeOnTheseArray.join('') + '])', 'g');
     if (wordBoundaryMorphemes && wordBoundaryMorphemes.length > 0) {
       doc.wordBoundaryMorphemesRegExp = new RegExp('([' + wordBoundaryMorphemes.join() + '])', 'g');
       text = text.replace(doc.wordBoundaryMorphemesRegExp, ' $1 ');

--- a/test/lexicon/Tokenizer-spec.js
+++ b/test/lexicon/Tokenizer-spec.js
@@ -46,6 +46,16 @@ describe('Tokenizer construction', function() {
     expect(doc.orthographicWords).toEqual(['This', 'has', 'BBB', 'rewrite', 'rules']);
   });
 
+  describe('language detection', function() {
+    describe('japanese', function() {
+      it('should detect japanese', function() {
+        var doc = Tokenizer.tokenizeInput({
+          orthography: '伊豆の伊東にヒロポン屋というものが存在している。旅館の番頭にさそわれてヤキトリ屋へ一パイのみに行って、元ダンサーという女中を相手にのんでいると、まッ黒いフロシキ包み（一尺四方ぐらい）を背負ってはいってきた二十五六の青年がある。女中がついと立って何か話していたが、二人でトントン二階へあがっていった。 三分ぐらいで降りて戻ってきたが、男が立ち去ると、 「あの人、',
+        });
+        expect(doc.orthographicWords).toEqual([ '伊豆', 'の', '伊東', 'に', 'ヒロポン屋というも', 'の', 'が存在している', '旅館', 'の', '番頭', 'に', 'さそわれてヤキトリ屋へ一パイ', 'の', 'み', 'に', '行って', '元ダンサ', 'という女中を相手', 'に', 'の', 'んでいると', 'まッ黒いフロシキ包み（一尺四方ぐらい）を背負ってはいってきた二十五六', 'の', '青年がある', '女中がついと立って何か話していたが', '二人でトントン二階へあがっていった', '三分ぐらいで降りて戻ってきたが', '男が立ち去ると', 'あ', 'の', '人' ]);
+      });
+    });
+  });
 });
 
 describe('Tokenizer construction', function() {


### PR DESCRIPTION
for iLanguage/iLanguageCloud#72  


![screen shot 2015-06-05 at 5 03 18 pm](https://cloud.githubusercontent.com/assets/12688769/8015232/d1c09aa0-0ba4-11e5-877b-70edcd0d5a56.png)



I looked into using japanese particles ot indicate word boundaries https://en.wiktionary.org/wiki/Category:Japanese_particles and into the https://github.com/iLanguage/JapaneseCorpusAngoSakaguchi/blob/master/japanese_segmentation.groovy  but they result in too many segmentations. In this pr i just added 2 particles to see if it helps hopefully more than it hinders: 

Sample text:

> 伊豆の伊東にヒロポン屋というものが存在している。旅館の番頭にさそわれてヤキトリ屋へ一パイのみに行って、元ダンサーという女中を相手にのんでいると、まッ黒いフロシキ包み（一尺四方ぐらい）を背負ってはいってきた二十五六の青年がある。女中がついと立って何か話していたが、二人でトントン二階へあがっていった。 　三分ぐらいで降りて戻ってきたが、男が立ち去ると、 「あの人、ヒロポン売る人よ。一箱百円よ。原価六十何円かだから、そんなに高くないでしょ」 　という。東京では、百二十円から、百四十円だそうである。 　ヒロポン屋は遊楽街を御用聞きにまわっているのである。最も濫用しているのはダンサーだそうで、皮下では利きがわるいから、静脈へ打つのだそうだ。 「いま、うってきたのよ」 　と云って、女中は左腕をだして静脈をみせた。五六本、アトがある。中毒というほどではない。ダンサー時代はよく打ったが、今は打たなくともいられる、睡気ざましじゃなくて、打ったトタンに気持がよいから打つのだと言っていた。 　この女中は、自分で静脈へうつのだそうだ。 「たいがい、そうよ。ヒロポンの静脈注射ぐらい、一人でやるのが普通よ。かえって看護婦あがりの人なんかがダメね。人にやってもらってるわ」 　そうかも知れない。看護婦ともなればブドウ糖の注射でも注意を集中してやるものだ。ウカツに静脈注射など打つ気持にはなれないかも知れない。 　織田作之助はヒロポン注射が得意で、酒席で、にわかに腕をまくりあげてヒロポンをうつ。当時の流行の尖端だから、ひとつは見栄だろう。今のように猫もシャクシもやるようになっては、彼もやる気がしなかったかも知れぬ。 　織田はヒロポンの注射をうつと、ビタミンＢをうち、救心をのんでいた。今でもこの風俗は同じことで、ヒロポン・ビタミン・救心。妙な信仰だ。しかし、今の中毒患者はヒロポン代で精一パイだから、信仰は残っているが、めったに実行はされない。 「ビタミンＢうって救心のむと、ほんとは中毒しないんだけど」 　などゝ、中毒の原因がそッちの方へ転嫁されている有様である。救心という薬は味も効能も仁丹ぐらいにしか思われてないが、べラボーに高価なところが信仰されるのかも知れない。しかし織田が得々とうっていたヒロポンも皮下注射で、今日ではまったく流行おくれなのである。第一、うつ量も、今日の流行にくらべると問題にならない。 　私は以前から錠剤の方を用いていたが、織田にすすめられて、注射をやってみた。 　注射は非常によろしくない。中毒するのが当然なのである。なぜなら、うったトタンに利いてくるが、一時間もたつと効能がうすれてしまう。誰しも覚醒剤を用いる場合は、もっと長時間の覚醒が必要な場合にきまっているから、日に何回となく打たなければならなくなって、次第に中毒してしまう。 　錠剤の方は一日一回でたくさんだ。ヒロポンの錠剤は半日持続しないが、ゼドリンは一日ちかく持続する。副作用もヒロポンほどでなく、錠剤を用いるなら、ゼドリンの方がはるかによい。 　錠剤は胃に悪く、蓄積するから危険だというが、これはウソで、胃に悪いといっても目立つほどでなく、煙草にくらべれば、はるかに胃の害はすくない。蓄積という点も、私はアルコールを用いて睡ったせいか、アルコールには溶解し易いそうで、そのせいか蓄積の害はあんまり気付かなかった。私の仕事の性質として、一週間か十日は連続して服用する必要がある。あと三四日は服用をやめて休息する。すると連続服用のあとは、服用をやめてからも二日間ぐらいは利いている。その程度であった。しかし私の場合はウイスキーをのむから、これに溶けてハイセツされて蓄積が少いということも考えられ、ウイスキーをのまない人の場合のことはわからない。 　精神科のお医者さんの話でも、あれを溶解ハイセツするにはウイスキーがいちばんよいらしいとのことで、私の経験によっても、錠剤を用いる限りは、ウイスキーをのんで眠って、十日のうち三日ぐらいずつ服用を中止していると、殆ど害はないようだ。 　又、服用の量も、累進するということはない。これは多分に気のせいがあって、昨日よりも余計のまないと利かないような気がするだけだ。 　ただ、実際、利かない場合が一度だけある。それは三四日服用を中止したのち、改めて服用しはじめた第一日目で、この時だけは、なかなか利かない。つまり蓄積がきれているせいだろう。したがって、その反対に、蓄積すれば小量のんで利くことが成り立つわけで、事実その通りなのである。だから、第一日目だけ、当人の定量より多い目にのむ必要があるが、翌日はもう定量でよく、三日目、四日目は定量以下へ減らしても利く。多くの人は、このことを御存じない。どうしても定量、又は定量以上のむ必要があると思いこんでいるのである。 　私の場合で云うと、私はゼドリンの二ミリの錠剤を七ツぐらいずつのむ習慣だった。一ミリなら十四のわけだが、どうも、二ミリ七ツの方が利くようである。これは製造元でたしかめると分るだろう。二ミリ七ツというのは普通の定量より倍量ちかく多いが、しかし、私は四五年もつづけていて、これで充分だったのである。織田にしても日に最低三十ミりは注射していたし、現在ダンサーの多くは三十ミリの注射ぐらい、朝メシ前という状態である。注射だと、どうしても、そうなりやすい。 　私は七ツの定量のところ、第一日目だけ、九ツのむ。二日目は七ツでよく、三日目、四日目は、六ツ、五ツと下げ、四ツですむこともあった。利かなかったら、またのめばよいのだから、はじめは小量でためしてみることがカンジンで、覚醒剤は累進して用いないと利かないという信仰を盲信してはいけないのである。 　したがって、私は覚醒剤の害というものを経験したことはなかった。 　害のひどいのは催眠薬だ。



Before: 

<img width="725" alt="screen shot 2017-11-19 at 3 22 51 pm" src="https://user-images.githubusercontent.com/196199/32995063-8b874298-cd3d-11e7-981c-4d5b9b654d28.png">


After: 

<img width="756" alt="screen shot 2017-11-19 at 3 25 06 pm" src="https://user-images.githubusercontent.com/196199/32995089-da11683a-cd3d-11e7-889a-14f70bf6aec2.png">
